### PR TITLE
Feat/15 Setting Database

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -15,15 +15,26 @@ jobs:
   springboot-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Navigate to backend directory
         run: cd backend
+    
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Set up JDK 23
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 23
+          distribution: 'temurin'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Custom
+mysql_logs/
+.env*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # NBE4-5-2-Team09
 
 프로그래머스 백엔드 데브코스 4기 5회차 9팀 시고르백구의 2차 팀 프로젝트입니다.
+
+## 🛠️ Development Setup
+
+**Run Database (Docker Compose)**
+
+```bash
+# Start MySQL container with Docker Compose
+# in root directory
+docker-compose up -d
+
+# Monitoring Logs
+# Since logs are mapped to your local machine in ./mysql/conf, you can monitor them directly:
+tail -f ./mysql_logs/general.log
+
+# Stop Containers
+docker-compose down
+
+```

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,11 +33,18 @@ dependencies {
 	testRuntimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
+
+	testImplementation("org.springframework.boot:spring-boot-starter-test") {
+		exclude group: "org.mockito"
+	}
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+    systemProperty 'spring.profiles.active', 'test'
 }

--- a/backend/flyway.conf
+++ b/backend/flyway.conf
@@ -1,0 +1,4 @@
+flyway.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=UTC&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&connectTimeout=20000&useSSL=false
+flyway.user=${DB_USERNAME}
+flyway.password=${DB_PASSWORD}
+flyway.locations=filesystem:src/main/resources/db/migration

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,21 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+        default_batch_fetch_size: 100
+
+  flyway:
+    enabled: false # true after deploy
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.orm.jdbc.extract: TRACE
+    org.springframework.transaction.interceptor: TRACE

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,13 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+  flyway:
+    enabled: true
+    validateOnMigrate: true
+    cleanDisabled: true
+
+logging:
+  level:
+    org.hibernate: warn

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:db_test;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,38 @@
+server:
+  port: ${SERVER_PORT:8080}
+
+spring:
+  application:
+    name: coing
+  profiles:
+    active: ${SPRING_ACTIVE_PROFILES:dev}
+  config:
+    import: optional:file:../.env[.properties]
+  output:
+    ansi:
+      enabled: always
+  jackson:
+    serialization:
+      fail-on-empty-beans: false
+
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=UTC&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&connectTimeout=20000&useSSL=false
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      auto-commit: false
+
+  jpa:
+    open-in-view: false
+
+  flyway: # managing database migration
+    enabled: false
+    baseline-on-migrate: true
+    baseline-version: 0
+    fail-on-missing-locations: true
+    locations: classpath:db/migration
+
+
+springdoc:
+  default-produces-media-type: application/json;charset=UTF-8

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+services:
+  db:
+    image: mysql:8.0
+    container_name: mysql
+    restart: always
+    env_file:
+      - .env
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT}:3306"
+    command: --general-log=1 --general-log-file=/etc/mysql/conf.d/general.log
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./mysql_logs:/etc/mysql/conf.d
+
+volumes:
+  db_data:


### PR DESCRIPTION
## 연관된 이슈

#15 

## 작업 내용

1. application.yml 환경 분리
2. Flyway 구성
    : 운영(prod) 환경에서 데이터베이스 스키마 마이그레이션을 위해 Flyway를 도입했습니다.
     1차 배포전까지 빠른 개발을 위해 JPA의 ddl-auto: update를 사용하고, Flyway를 비활성화한 상태입니다.(**현재 미사용, 설정파일만 존재**)
     
## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

각자 로컬에서 root 폴더(최상위 폴더)에 `.env`파일을 추가해야 합니다. 해당 파일은 [노션 팀 페이지](https://www.notion.so/Team-09-1a63550b7b5580c0a13fc20b7dc7ccbd?pvs=4#1a83550b7b5580bab71cfa316149a4ea)에 추가해놓았습니다.

closes #15