### PR TITLE
Feat/11 ticker get

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,13 +46,15 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
-	testImplementation 'org.mockito:mockito-core:4.6.1'
-	testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
-	testImplementation 'org.awaitility:awaitility:4.3.0'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
+    testImplementation 'org.awaitility:awaitility:4.3.0'
 
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.3'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/coing/domain/coin/ticker/dto/TickerDto.java
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/dto/TickerDto.java
@@ -1,0 +1,82 @@
+package com.coing.domain.coin.ticker.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import com.coing.domain.coin.ticker.entity.Ticker;
+import com.coing.domain.coin.ticker.entity.enums.AskBid;
+import com.coing.domain.coin.ticker.entity.enums.Change;
+import com.coing.domain.coin.ticker.entity.enums.MarketState;
+import com.coing.domain.coin.ticker.entity.enums.MarketWarning;
+
+import lombok.Builder;
+
+@Builder
+public record TickerDto(
+	String type, // 데이터 타입 (예: "ticker")
+	String code, // 마켓 코드 (예: "KRW-BTC")
+	double openingPrice, // 시가
+	double highPrice, // 고가
+	double lowPrice, // 저가
+	double tradePrice, // 현재가
+	double prevClosingPrice, // 전일 종가
+	Change change, // 전일 대비
+	double changePrice, // 전일 대비 값
+	double signedChangePrice, // 전일 대비 값 (부호 포함)
+	double changeRate, // 전일 대비 변동률
+	double signedChangeRate, // 전일 대비 변동률 (부호 포함)
+	double tradeVolume, // 가장 최근 거래량
+	double accTradeVolume, // 누적 거래량
+	double accTradeVolume24h, // 24시간 누적 거래량
+	double accTradePrice, // 누적 거래대금
+	double accTradePrice24h, // 24시간 누적 거래대금
+	LocalDate tradeDate, // 최근 거래 일자
+	LocalTime tradeTime, // 최근 거래 시각
+	Long tradeTimestamp, // 체결 타임스탬프
+	AskBid askBid, // 매수/매도 구분
+	double accAskVolume, // 누적 매도량
+	double accBidVolume, // 누적 매수량
+	double highest52WeekPrice, // 52주 최고가
+	LocalDate highest52WeekDate, // 52주 최고가 달성일
+	double lowest52WeekPrice, // 52주 최저가
+	LocalDate lowest52WeekDate, // 52주 최저가 달성일
+	MarketState marketState, // 거래 상태
+	MarketWarning marketWarning, // 유의 종목 여부
+	Long timestamp // 타임스탬프
+) {
+
+	public static TickerDto from(Ticker ticker) {
+		return TickerDto.builder()
+			.type(ticker.getType())
+			.code(ticker.getCode())
+			.openingPrice(ticker.getOpeningPrice())
+			.highPrice(ticker.getHighPrice())
+			.lowPrice(ticker.getLowPrice())
+			.tradePrice(ticker.getTradePrice())
+			.prevClosingPrice(ticker.getPrevClosingPrice())
+			.change(ticker.getChange())
+			.changePrice(ticker.getChangePrice())
+			.signedChangePrice(ticker.getSignedChangePrice())
+			.changeRate(ticker.getChangeRate())
+			.signedChangeRate(ticker.getSignedChangeRate())
+			.tradeVolume(ticker.getTradeVolume())
+			.accTradeVolume(ticker.getAccTradeVolume())
+			.accTradeVolume24h(ticker.getAccTradeVolume24h())
+			.accTradePrice(ticker.getAccTradePrice())
+			.accTradePrice24h(ticker.getAccTradePrice24h())
+			.tradeDate(ticker.getTradeDate())
+			.tradeTime(ticker.getTradeTime())
+			.tradeTimestamp(ticker.getTradeTimestamp())
+			.askBid(ticker.getAskBid())
+			.accAskVolume(ticker.getAccAskVolume())
+			.accBidVolume(ticker.getAccBidVolume())
+			.highest52WeekPrice(ticker.getHighest52WeekPrice())
+			.highest52WeekDate(ticker.getHighest52WeekDate())
+			.lowest52WeekPrice(ticker.getLowest52WeekPrice())
+			.lowest52WeekDate(ticker.getLowest52WeekDate())
+			.marketState(ticker.getMarketState())
+			.marketWarning(ticker.getMarketWarning())
+			.timestamp(ticker.getTimestamp())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/coing/domain/coin/ticker/entity/Ticker.java
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/entity/Ticker.java
@@ -1,0 +1,51 @@
+package com.coing.domain.coin.ticker.entity;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import com.coing.domain.coin.ticker.entity.enums.AskBid;
+import com.coing.domain.coin.ticker.entity.enums.Change;
+import com.coing.domain.coin.ticker.entity.enums.MarketState;
+import com.coing.domain.coin.ticker.entity.enums.MarketWarning;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Ticker {
+	private String type; // 데이터 타입 (예: "ticker")
+	private String code; // 마켓 코드 (예: "KRW-BTC")
+	private double openingPrice; // 시가
+	private double highPrice; // 고가
+	private double lowPrice; // 저가
+	private double tradePrice; // 현재가
+	private double prevClosingPrice; // 전일 종가
+	private Change change; // 전일 대비
+	private double changePrice; // 전일 대비 값
+	private double signedChangePrice; // 전일 대비 값 (부호 포함)
+	private double changeRate; // 전일 대비 변동률
+	private double signedChangeRate; // 전일 대비 변동률 (부호 포함)
+	private double tradeVolume; // 가장 최근 거래량
+	private double accTradeVolume; // 누적 거래량
+	private double accTradeVolume24h; // 24시간 누적 거래량
+	private double accTradePrice; // 누적 거래대금
+	private double accTradePrice24h; // 24시간 누적 거래대금
+	private LocalDate tradeDate; // 최근 거래 일자
+	private LocalTime tradeTime; // 최근 거래 시각
+	private Long tradeTimestamp; // 체결 타임스탬프
+	private AskBid askBid; // 매수/매도 구분
+	private double accAskVolume; // 누적 매도량
+	private double accBidVolume; // 누적 매수량
+	private double highest52WeekPrice; // 52주 최고가
+	private LocalDate highest52WeekDate; // 52주 최고가 달성일
+	private double lowest52WeekPrice; // 52주 최저가
+	private LocalDate lowest52WeekDate; // 52주 최저가 달성일
+	private MarketState marketState; // 거래 상태
+	private MarketWarning marketWarning; // 유의 종목 여부
+	private Long timestamp; // 타임스탬프
+}

--- a/backend/src/main/java/com/coing/domain/coin/ticker/entity/enums/AskBid.java
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/entity/enums/AskBid.java
@@ -1,0 +1,6 @@
+package com.coing.domain.coin.ticker.entity.enums;
+
+public enum AskBid {
+	ASK,   // 매도
+	BID,   // 매수
+}

--- a/backend/src/main/java/com/coing/domain/coin/ticker/entity/enums/Change.java
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/entity/enums/Change.java
@@ -1,0 +1,7 @@
+package com.coing.domain.coin.ticker.entity.enums;
+
+public enum Change {
+	RISE, // 상승
+	EVEN, // 보합
+	FALL // 하락
+}

--- a/backend/src/main/java/com/coing/domain/coin/ticker/entity/enums/MarketState.java
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/entity/enums/MarketState.java
@@ -1,0 +1,7 @@
+package com.coing.domain.coin.ticker.entity.enums;
+
+public enum MarketState {
+	PREVIEW,  // 입금지원
+	ACTIVE,   // 거래지원 가능
+	DELISTED, // 거래지원 종료
+}

--- a/backend/src/main/java/com/coing/domain/coin/ticker/entity/enums/MarketWarning.java
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/entity/enums/MarketWarning.java
@@ -1,0 +1,6 @@
+package com.coing.domain.coin.ticker.entity.enums;
+
+public enum MarketWarning {
+	NONE,     // 유의 종목 아님
+	CAUTION,  // 유의 종목
+}

--- a/backend/src/main/java/com/coing/domain/coin/ticker/service/TickerService.java
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/service/TickerService.java
@@ -1,0 +1,23 @@
+package com.coing.domain.coin.ticker.service;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+import com.coing.domain.coin.ticker.dto.TickerDto;
+import com.coing.domain.coin.ticker.entity.Ticker;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TickerService {
+	private final SimpMessageSendingOperations simpMessageSendingOperations;
+
+	/**
+	 * WebSocket을 통해 실시간 Ticker 데이터 publish
+	 */
+	public void publish(Ticker ticker) {
+		TickerDto dto = TickerDto.from(ticker);
+		simpMessageSendingOperations.convertAndSend("/sub/coin/ticker", dto);
+	}
+}

--- a/backend/src/main/java/com/coing/global/config/JacksonConfig.java
+++ b/backend/src/main/java/com/coing/global/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package com.coing.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JacksonConfig {
+	@Bean
+	public ObjectMapper objectMapper() {
+		return new ObjectMapper()
+			.registerModule(new JavaTimeModule()) // Java 8 날짜/시간 지원 추가
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // timestamp 변환 방지
+	}
+}

--- a/backend/src/main/java/com/coing/infra/upbit/adapter/UpbitDataService.java
+++ b/backend/src/main/java/com/coing/infra/upbit/adapter/UpbitDataService.java
@@ -4,7 +4,10 @@ import org.springframework.stereotype.Service;
 
 import com.coing.domain.coin.orderbook.entity.Orderbook;
 import com.coing.domain.coin.orderbook.service.OrderbookService;
+import com.coing.domain.coin.ticker.entity.Ticker;
+import com.coing.domain.coin.ticker.service.TickerService;
 import com.coing.infra.upbit.dto.UpbitWebSocketOrderbookDto;
+import com.coing.infra.upbit.dto.UpbitWebSocketTickerDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class UpbitDataService {
 	private final OrderbookService orderbookService;
+	private final TickerService tickerService;
 
 	public void processOrderbookData(UpbitWebSocketOrderbookDto dto) {
 		Orderbook orderbook = dto.toEntity();
@@ -26,5 +30,10 @@ public class UpbitDataService {
 		orderbookService.updateLatestOrderbook(orderbook);
 
 		orderbookService.publish(orderbook);
+	}
+
+	public void processTickerData(UpbitWebSocketTickerDto dto) {
+		Ticker ticker = dto.toEntity();
+		tickerService.publish(ticker);
 	}
 }

--- a/backend/src/main/java/com/coing/infra/upbit/adapter/UpbitWebSocketService.java
+++ b/backend/src/main/java/com/coing/infra/upbit/adapter/UpbitWebSocketService.java
@@ -2,6 +2,7 @@ package com.coing.infra.upbit.adapter;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,7 @@ import org.springframework.web.socket.client.WebSocketClient;
 import com.coing.infra.upbit.enums.EnumUpbitWebSocketType;
 import com.coing.infra.upbit.handler.UpbitWebSocketHandler;
 import com.coing.infra.upbit.handler.UpbitWebSocketOrderbookHandler;
+import com.coing.infra.upbit.handler.UpbitWebSocketTickerHandler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UpbitWebSocketService {
 	private final WebSocketClient webSocketClient;
 	private final UpbitWebSocketOrderbookHandler orderbookHandler;
+	private final UpbitWebSocketTickerHandler tickerHandler;
 	private final Map<EnumUpbitWebSocketType, UpbitWebSocketConnection> connections = new HashMap<>();
 	@Value("${upbit.websocket.uri}")
 	private String UPBIT_WEBSOCKET_URI;
@@ -45,6 +48,15 @@ public class UpbitWebSocketService {
 		connections.put(EnumUpbitWebSocketType.ORDERBOOK, orderbookConn);
 		orderbookConn.connect();
 
+		// TICKER
+		UpbitWebSocketHandler tickerComposite = new UpbitWebSocketHandler(
+			List.of(tickerHandler)
+		);
+		UpbitWebSocketConnection tickerConn = new UpbitWebSocketConnection(
+			webSocketClient, tickerComposite, UPBIT_WEBSOCKET_URI, "TICKER"
+		);
+		connections.put(EnumUpbitWebSocketType.TICKER, tickerConn);
+		tickerConn.connect();
 	}
 
 	/**

--- a/backend/src/main/java/com/coing/infra/upbit/dto/UpbitWebSocketTickerDto.java
+++ b/backend/src/main/java/com/coing/infra/upbit/dto/UpbitWebSocketTickerDto.java
@@ -1,0 +1,157 @@
+package com.coing.infra.upbit.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import com.coing.domain.coin.ticker.entity.Ticker;
+import com.coing.domain.coin.ticker.entity.enums.AskBid;
+import com.coing.domain.coin.ticker.entity.enums.Change;
+import com.coing.domain.coin.ticker.entity.enums.MarketState;
+import com.coing.domain.coin.ticker.entity.enums.MarketWarning;
+import com.coing.util.LocalDateDeserializer;
+import com.coing.util.LocalTimeDeserializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UpbitWebSocketTickerDto {
+	@JsonProperty("ty")
+	private String type;
+
+	@JsonProperty("cd")
+	private String code;
+
+	@JsonProperty("op")
+	private Double openingPrice;
+
+	@JsonProperty("hp")
+	private Double highPrice;
+
+	@JsonProperty("lp")
+	private Double lowPrice;
+
+	@JsonProperty("tp")
+	private Double tradePrice;
+
+	@JsonProperty("pcp")
+	private Double prevClosingPrice;
+
+	@JsonProperty("c")
+	private Change change;
+
+	@JsonProperty("cp")
+	private Double changePrice;
+
+	@JsonProperty("scp")
+	private Double signedChangePrice;
+
+	@JsonProperty("cr")
+	private Double changeRate;
+
+	@JsonProperty("scr")
+	private Double signedChangeRate;
+
+	@JsonProperty("tv")
+	private Double tradeVolume;
+
+	@JsonProperty("atv")
+	private Double accTradeVolume;
+
+	@JsonProperty("atv24h")
+	private Double accTradeVolume24h;
+
+	@JsonProperty("atp")
+	private Double accTradePrice;
+
+	@JsonProperty("atp24h")
+	private Double accTradePrice24h;
+
+	@JsonProperty("tdt")
+	@JsonDeserialize(using = LocalDateDeserializer.class)
+	private LocalDate tradeDate;
+
+	@JsonProperty("ttm")
+	@JsonDeserialize(using = LocalTimeDeserializer.class)
+	private LocalTime tradeTime;
+
+	@JsonProperty("ttms")
+	private Long tradeTimestamp;
+
+	@JsonProperty("ab")
+	private AskBid askBid;
+
+	@JsonProperty("aav")
+	private Double accAskVolume;
+
+	@JsonProperty("abv")
+	private Double accBidVolume;
+
+	@JsonProperty("h52wp")
+	private Double highest52WeekPrice;
+
+	@JsonProperty("h52wdt")
+	private LocalDate highest52WeekDate;
+
+	@JsonProperty("l52wp")
+	private Double lowest52WeekPrice;
+
+	@JsonProperty("l52wdt")
+	private LocalDate lowest52WeekDate;
+
+	@JsonProperty("ms")
+	private MarketState marketState;
+
+	@JsonProperty("mw")
+	private MarketWarning marketWarning;
+
+	@JsonProperty("tms")
+	private Long timestamp;
+
+	@JsonProperty("st")
+	private String streamType;
+
+	public Ticker toEntity() {
+		return Ticker.builder()
+			.type(type)
+			.code(code)
+			.openingPrice(openingPrice)
+			.highPrice(highPrice)
+			.lowPrice(lowPrice)
+			.tradePrice(tradePrice)
+			.prevClosingPrice(prevClosingPrice)
+			.change(change)
+			.changePrice(changePrice)
+			.signedChangePrice(signedChangePrice)
+			.changeRate(changeRate)
+			.signedChangeRate(signedChangeRate)
+			.tradeVolume(tradeVolume)
+			.accTradeVolume(accTradeVolume)
+			.accTradeVolume24h(accTradeVolume24h)
+			.accTradePrice(accTradePrice)
+			.accTradePrice24h(accTradePrice24h)
+			.tradeDate(tradeDate)
+			.tradeTime(tradeTime)
+			.tradeTimestamp(tradeTimestamp)
+			.askBid(askBid)
+			.accAskVolume(accAskVolume)
+			.accBidVolume(accBidVolume)
+			.highest52WeekPrice(highest52WeekPrice)
+			.highest52WeekDate(highest52WeekDate)
+			.lowest52WeekPrice(lowest52WeekPrice)
+			.lowest52WeekDate(lowest52WeekDate)
+			.marketState(marketState)
+			.marketWarning(marketWarning)
+			.timestamp(timestamp)
+			.build();
+	}
+}

--- a/backend/src/main/java/com/coing/infra/upbit/handler/UpbitWebSocketTickerHandler.java
+++ b/backend/src/main/java/com/coing/infra/upbit/handler/UpbitWebSocketTickerHandler.java
@@ -1,0 +1,57 @@
+package com.coing.infra.upbit.handler;
+
+import static com.coing.util.Ut.Upbit.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.BinaryMessage;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.BinaryWebSocketHandler;
+
+import com.coing.infra.upbit.adapter.UpbitDataService;
+import com.coing.infra.upbit.dto.UpbitWebSocketTickerDto;
+import com.coing.infra.upbit.enums.EnumUpbitRequestType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UpbitWebSocketTickerHandler extends BinaryWebSocketHandler {
+	private final ObjectMapper objectMapper;
+	private final UpbitDataService upbitDataService;
+
+	@Override
+	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+		log.info("Upbit WebSocket Ticker connection established.");
+		String subscribeMessage = makeRequest(EnumUpbitRequestType.TICKER);
+		session.sendMessage(new TextMessage(subscribeMessage));
+	}
+
+	@Override
+	public void handleBinaryMessage(WebSocketSession session, BinaryMessage message) {
+		String payload = new String(message.getPayload().array(), StandardCharsets.UTF_8);
+
+		if (!payload.isEmpty()) {
+			processMessage(payload);
+		}
+	}
+
+	private void processMessage(String payload) {
+		try {
+			if ("{\"status\":\"UP\"}".equals(payload)) {
+				log.debug("Received keepalive message: {}", payload);
+				return;
+			}
+
+			UpbitWebSocketTickerDto tickerDto = objectMapper.readValue(payload, UpbitWebSocketTickerDto.class);
+			upbitDataService.processTickerData(tickerDto);
+		} catch (Exception e) {
+			log.error("Error processing ticker message: {}", payload, e);
+		}
+	}
+}

--- a/backend/src/main/java/com/coing/util/LocalDateDeserializer.java
+++ b/backend/src/main/java/com/coing/util/LocalDateDeserializer.java
@@ -1,0 +1,18 @@
+package com.coing.util;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class LocalDateDeserializer extends JsonDeserializer<LocalDate> {
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+	@Override
+	public LocalDate deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+		return LocalDate.parse(p.getText(), FORMATTER);
+	}
+}

--- a/backend/src/main/java/com/coing/util/LocalTimeDeserializer.java
+++ b/backend/src/main/java/com/coing/util/LocalTimeDeserializer.java
@@ -1,0 +1,18 @@
+package com.coing.util;
+
+import java.io.IOException;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class LocalTimeDeserializer extends JsonDeserializer<LocalTime> {
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
+
+	@Override
+	public LocalTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+		return LocalTime.parse(p.getText(), FORMATTER);
+	}
+}

--- a/backend/src/test/java/com/coing/domain/coin/ticker/service/TickerServiceTest.java
+++ b/backend/src/test/java/com/coing/domain/coin/ticker/service/TickerServiceTest.java
@@ -1,0 +1,99 @@
+package com.coing.domain.coin.ticker.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+
+import com.coing.domain.coin.ticker.dto.TickerDto;
+import com.coing.domain.coin.ticker.entity.Ticker;
+import com.coing.domain.coin.ticker.entity.enums.AskBid;
+import com.coing.domain.coin.ticker.entity.enums.Change;
+import com.coing.domain.coin.ticker.entity.enums.MarketState;
+import com.coing.domain.coin.ticker.entity.enums.MarketWarning;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+public class TickerServiceTest {
+
+	@Mock
+	private SimpMessageSendingOperations simpMessageSendingOperations;
+
+	@InjectMocks
+	private TickerService tickerService;
+
+	@Autowired
+	private ObjectMapper mapper;
+
+	private Ticker testTicker;
+
+	@BeforeEach
+	public void setUp() {
+		LocalDate tradeDate = LocalDate.now();
+		LocalTime tradeTime = LocalTime.now();
+		testTicker = Ticker.builder()
+			.type("ticker")
+			.code("KRW-BTC")
+			.openingPrice(100.0)
+			.highPrice(120.0)
+			.lowPrice(90.0)
+			.tradePrice(110.0)
+			.prevClosingPrice(105.0)
+			.change(Change.RISE)
+			.changePrice(5.0)
+			.signedChangePrice(5.0)
+			.changeRate(0.05)
+			.signedChangeRate(0.05)
+			.tradeVolume(500.0)
+			.accTradeVolume(10000.0)
+			.accTradeVolume24h(12000.0)
+			.accTradePrice(1000000.0)
+			.accTradePrice24h(1200000.0)
+			.tradeDate(tradeDate)
+			.tradeTime(tradeTime)
+			.tradeTimestamp(System.currentTimeMillis())
+			.askBid(AskBid.BID)
+			.accAskVolume(5000.0)
+			.accBidVolume(6000.0)
+			.highest52WeekPrice(130.0)
+			.highest52WeekDate(LocalDate.of(2024, 1, 1))
+			.lowest52WeekPrice(80.0)
+			.lowest52WeekDate(LocalDate.of(2023, 1, 1))
+			.marketState(MarketState.ACTIVE)
+			.marketWarning(MarketWarning.NONE)
+			.timestamp(System.currentTimeMillis())
+			.build();
+	}
+
+	@Test
+	@DisplayName("publish 성공 - WebSocket을 통해 데이터 전송")
+	void publish() throws JsonProcessingException {
+		// when
+		tickerService.publish(testTicker);
+
+		// then
+		ArgumentCaptor<TickerDto> captor = ArgumentCaptor.forClass(TickerDto.class);
+		verify(simpMessageSendingOperations, times(1))
+			.convertAndSend(eq("/sub/coin/ticker"), captor.capture());
+
+		TickerDto sentDto = captor.getValue();
+		String actualValue = mapper.writeValueAsString(sentDto);
+		JsonNode jsonNode = mapper.readTree(actualValue);
+
+		assertEquals("ticker", jsonNode.get("type").asText());
+		assertEquals("KRW-BTC", jsonNode.get("code").asText());
+	}
+}

--- a/backend/src/test/java/com/coing/infra/upbit/adapter/UpbitWebSocketServiceTest.java
+++ b/backend/src/test/java/com/coing/infra/upbit/adapter/UpbitWebSocketServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.web.socket.client.WebSocketClient;
 
 import com.coing.infra.upbit.enums.EnumUpbitWebSocketType;
 import com.coing.infra.upbit.handler.UpbitWebSocketOrderbookHandler;
+import com.coing.infra.upbit.handler.UpbitWebSocketTickerHandler;
 
 @ExtendWith(MockitoExtension.class)
 public class UpbitWebSocketServiceTest {
@@ -26,6 +27,9 @@ public class UpbitWebSocketServiceTest {
 
     @Mock
     private UpbitWebSocketOrderbookHandler orderbookHandler;
+
+	@Mock
+	private UpbitWebSocketTickerHandler tickerHandler;
 
     @InjectMocks
     private UpbitWebSocketService service;
@@ -49,7 +53,7 @@ public class UpbitWebSocketServiceTest {
             (Map<EnumUpbitWebSocketType, UpbitWebSocketConnection>)
             ReflectionTestUtils.getField(service, "connections");
 
-		assertEquals(1, connections.size());
+		assertEquals(2, connections.size());
 	}
 
 	@Test


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호

#11

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 현재가 데이터를 조회하는 로직을 구현했습니다.(데이터 가공x. 단순 전달)
- 업비트에서 받은 데이터를 파싱하기 위해 ObjectMapper를 커스텀하는 코드를 추가했습니다.

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요

- 일단 현재가 조회를 UI까지 구현한 후 데이터 가공이나 DB 저장 여부를 결정하고자 합니다.
- 업비트에서 제공하는 현재가 데이터에는 timestamp가 2가지 있습니다. (체결 당시 시각/전송 당시(?) 시각) 
이 값들 대신 LocalDateTime.now()로 직접 timestamp를 생성해서 반환하는 게 좋을까요? 그냥 기존 타임스탬프 값을 그대로 반환하는 게 좋을까요?

closes #11