### PR TITLE
Feat/37 fetch coin by market

### DIFF
--- a/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
@@ -1,7 +1,8 @@
 package com.coing.domain.coin.market.controller;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,18 +27,17 @@ public class MarketController {
 
 	@Operation(summary = "마켓 전체 조회")
 	@GetMapping
-	public ResponseEntity<List<MarketResponse>> getMarkets() {
-		return ResponseEntity.ok(marketService.getAllMarkets().stream()
-			.map(MarketResponse::from)
-			.toList());
+	public ResponseEntity<Page<MarketResponse>> getMarkets(@PageableDefault(sort = "code") Pageable pageable) {
+		return ResponseEntity.ok(marketService.getAllMarkets(pageable)
+			.map(MarketResponse::from));
 	}
 
 	@Operation(summary = "기준 통화별 마켓 전체 조회")
 	@GetMapping("/quote")
-	public ResponseEntity<List<MarketResponse>> getMarketsByQuote(@RequestParam("type") String type) {
-		return ResponseEntity.ok(marketService.getAllMarketsByQuote(type).stream()
-			.map(MarketResponse::from)
-			.toList());
+	public ResponseEntity<Page<MarketResponse>> getMarketsByQuote(@RequestParam("type") String type,
+		@PageableDefault(sort = "code") Pageable pageable) {
+		return ResponseEntity.ok(marketService.getAllMarketsByQuote(type, pageable)
+			.map(MarketResponse::from));
 	}
 
 	@Operation(summary = "새로고침 요청")

--- a/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/coins")
+@RequestMapping("/api/market")
 @RequiredArgsConstructor
 @Tag(name = "Market API", description = "종목 조회 관련 API 엔드포인트")
 public class MarketController {

--- a/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.coing.domain.coin.market.controller.dto.MarketResponse;
@@ -25,8 +26,16 @@ public class MarketController {
 
 	@Operation(summary = "종목 전체 조회")
 	@GetMapping
-	public ResponseEntity<List<MarketResponse>> getMarkets() {
-		return ResponseEntity.ok(marketService.getAllMarkets().stream()
+	public ResponseEntity<List<MarketResponse>> getCoins() {
+		return ResponseEntity.ok(marketService.getAllCoins().stream()
+			.map(MarketResponse::from)
+			.toList());
+	}
+
+	@Operation(summary = "마켓별 종목 전체 조회")
+	@GetMapping("/market")
+	public ResponseEntity<List<MarketResponse>> getCoinsByMarket(@RequestParam("type") String type) {
+		return ResponseEntity.ok(marketService.getAllCoinsByMarket(type).stream()
 			.map(MarketResponse::from)
 			.toList());
 	}

--- a/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
@@ -24,18 +24,18 @@ public class MarketController {
 
 	private final MarketService marketService;
 
-	@Operation(summary = "종목 전체 조회")
+	@Operation(summary = "마켓 전체 조회")
 	@GetMapping
-	public ResponseEntity<List<MarketResponse>> getCoins() {
-		return ResponseEntity.ok(marketService.getAllCoins().stream()
+	public ResponseEntity<List<MarketResponse>> getMarkets() {
+		return ResponseEntity.ok(marketService.getAllMarkets().stream()
 			.map(MarketResponse::from)
 			.toList());
 	}
 
-	@Operation(summary = "마켓별 종목 전체 조회")
-	@GetMapping("/market")
-	public ResponseEntity<List<MarketResponse>> getCoinsByMarket(@RequestParam("type") String type) {
-		return ResponseEntity.ok(marketService.getAllCoinsByMarket(type).stream()
+	@Operation(summary = "기준 통화별 마켓 전체 조회")
+	@GetMapping("/quote")
+	public ResponseEntity<List<MarketResponse>> getMarketsByQuote(@RequestParam("type") String type) {
+		return ResponseEntity.ok(marketService.getAllMarketsByQuote(type).stream()
 			.map(MarketResponse::from)
 			.toList());
 	}

--- a/backend/src/main/java/com/coing/domain/coin/market/repository/MarketRepository.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/repository/MarketRepository.java
@@ -1,5 +1,7 @@
 package com.coing.domain.coin.market.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.coing.domain.coin.market.entity.Market;
 
 @Repository
 public interface MarketRepository extends JpaRepository<Market, String> {
+	List<Market> findByCodeStartingWith(String prefix);
 }

--- a/backend/src/main/java/com/coing/domain/coin/market/repository/MarketRepository.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/repository/MarketRepository.java
@@ -1,7 +1,7 @@
 package com.coing.domain.coin.market.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +9,5 @@ import com.coing.domain.coin.market.entity.Market;
 
 @Repository
 public interface MarketRepository extends JpaRepository<Market, String> {
-	List<Market> findByCodeStartingWith(String prefix);
+	Page<Market> findByCodeStartingWith(String prefix, Pageable pageable);
 }

--- a/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
@@ -55,13 +55,13 @@ public class MarketService {
 		}
 	}
 
-	public List<Market> getAllCoins() {
+	public List<Market> getAllMarkets() {
 		log.info("[Market] Get all market list");
 		return marketRepository.findAll();
 	}
 
-	public List<Market> getAllCoinsByMarket(String type) {
-		log.info("[Market] Get all KRW market list");
+	public List<Market> getAllMarketsByQuote(String type) {
+		log.info("[Market] Get all market list by quote currency");
 		return marketRepository.findByCodeStartingWith(type);
 	}
 

--- a/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
@@ -55,9 +55,14 @@ public class MarketService {
 		}
 	}
 
-	public List<Market> getAllMarkets() {
+	public List<Market> getAllCoins() {
 		log.info("[Market] Get all market list");
 		return marketRepository.findAll();
+	}
+
+	public List<Market> getAllCoinsByMarket(String type) {
+		log.info("[Market] Get all KRW market list");
+		return marketRepository.findByCodeStartingWith(type);
 	}
 
 	@Transactional

--- a/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -55,14 +57,14 @@ public class MarketService {
 		}
 	}
 
-	public List<Market> getAllMarkets() {
+	public Page<Market> getAllMarkets(Pageable pageable) {
 		log.info("[Market] Get all market list");
-		return marketRepository.findAll();
+		return marketRepository.findAll(pageable);
 	}
 
-	public List<Market> getAllMarketsByQuote(String type) {
+	public Page<Market> getAllMarketsByQuote(String type, Pageable pageable) {
 		log.info("[Market] Get all market list by quote currency");
-		return marketRepository.findByCodeStartingWith(type);
+		return marketRepository.findByCodeStartingWith(type, pageable);
 	}
 
 	@Transactional

--- a/backend/src/test/java/com/coing/domain/coin/market/service/MarketServiceTest.java
+++ b/backend/src/test/java/com/coing/domain/coin/market/service/MarketServiceTest.java
@@ -101,7 +101,7 @@ public class MarketServiceTest {
 		when(marketRepository.findAll()).thenReturn(mockMarkets);
 
 		// When
-		List<Market> markets = marketService.getAllCoins();
+		List<Market> markets = marketService.getAllMarkets();
 
 		// Then
 		assertNotNull(markets);
@@ -109,7 +109,7 @@ public class MarketServiceTest {
 	}
 
 	@Test
-	@DisplayName("t5: 마켓별 코인 목록 조회 - 정상 동작 테스트")
+	@DisplayName("t5: 기준 통화별 마켓 목록 조회 - 정상 동작 테스트")
 	void getAllCoinsByMarket_ShouldReturnFilteredMarkets() {
 		// given
 		String type = "KRW";
@@ -120,7 +120,7 @@ public class MarketServiceTest {
 		when(marketRepository.findByCodeStartingWith(type)).thenReturn(mockMarkets);
 
 		// when
-		List<Market> result = marketService.getAllCoinsByMarket(type);
+		List<Market> result = marketService.getAllMarketsByQuote(type);
 
 		// then
 		assertThat(result).hasSize(2);
@@ -129,14 +129,14 @@ public class MarketServiceTest {
 	}
 
 	@Test
-	@DisplayName("t5: 마켓별 코인 목록 조회 - 정확한 마켓명이 아닐 시 빈 리스트 반환")
+	@DisplayName("t5: 기준 통화별 마켓 목록 조회 - 정확한 기준 통화명이 아닐 시 빈 리스트 반환")
 	void getAllCoinsByMarket_ShouldReturnEmptyList_WhenNoMatchingMarkets() {
 		// given
 		String type = "USD";
 		when(marketRepository.findByCodeStartingWith(type)).thenReturn(Collections.emptyList());
 
 		// when
-		List<Market> result = marketService.getAllCoinsByMarket(type);
+		List<Market> result = marketService.getAllMarketsByQuote(type);
 
 		// then
 		assertThat(result).isEmpty();

--- a/backend/src/test/java/com/coing/domain/coin/market/service/MarketServiceTest.java
+++ b/backend/src/test/java/com/coing/domain/coin/market/service/MarketServiceTest.java
@@ -99,7 +99,7 @@ public class MarketServiceTest {
 		when(marketRepository.findAll()).thenReturn(mockMarkets);
 
 		// When
-		List<Market> markets = marketService.getAllMarkets();
+		List<Market> markets = marketService.getAllCoins();
 
 		// Then
 		assertNotNull(markets);


### PR DESCRIPTION
## 연관된 이슈

> #37 

## 작업 내용

> 기준 통화 별로 코인 목록을 반환하는 api를 작성했습니다. (KRW, BTC, USDT)
> Market.code의 prefix를 의미합니다. (KRW로 조회할 경우 KRW-BTC 등 원화로 거래되는 코인 목록 반환)
> 인기순, 시가순, 변동폭, 거래량 등의 정렬 및 필터링은 프론트에서 웹소켓으로 받은 데이터를 바탕으로 해야할 것 같습니다.

## 스크린샷 (선택)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #37