### PR TITLE
Feat/65 update websocket

### DIFF
--- a/frontend/src/app/coin/[market]/ClientPage.tsx
+++ b/frontend/src/app/coin/[market]/ClientPage.tsx
@@ -15,7 +15,8 @@ import { useWebSocket } from "@/app/context/WebSocketContext";
 
 export default function ClientPage() {
   const { market } = useParams() as { market: string };
-  const { ticker } = useWebSocket();
+  const { tickers } = useWebSocket();
+  const ticker = tickers?.[market] ?? null;
 
   // Mock data
   const orderbook = generateMockOrderbook();

--- a/frontend/src/app/coin/[market]/page.tsx
+++ b/frontend/src/app/coin/[market]/page.tsx
@@ -3,10 +3,8 @@ import WebSocketProvider from "@/app/context/WebSocketContext";
 
 export default function Page() {
   return (
-    <>
-      <WebSocketProvider subscriptions={["ticker"]}>
-        <ClientPage></ClientPage>
-      </WebSocketProvider>
-    </>
+    <WebSocketProvider subscriptions={[{ type: "ticker", markets: [] }]}>
+      <ClientPage />
+    </WebSocketProvider>
   );
 }

--- a/frontend/src/app/context/WebSocketContext.tsx
+++ b/frontend/src/app/context/WebSocketContext.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { useWebSocketStore } from "@/app/store/webSocketStore";
 import { IMessage } from "@stomp/stompjs";
-import { useParams, usePathname } from "next/navigation";
+import { usePathname, useParams } from "next/navigation";
 import type {
   TickerDto,
   OrderbookDto,
@@ -17,21 +17,26 @@ import type {
   CandleChartDto,
 } from "@/app/types";
 
-// 1. 가능한 구독 키들을 타입으로 정의
-type SubscriptionKey = "ticker" | "orderbook" | "trade" | "candle";
+// 구독 가능한 타입 정의
+type SubscriptionType = "ticker" | "orderbook" | "trade" | "candle";
+
+interface Subscription {
+  type: SubscriptionType;
+  markets?: string[]; // markets가 비어있을 수도 있음
+}
 
 interface WebSocketContextProps {
-  ticker: TickerDto | null;
-  orderbook: OrderbookDto | null;
-  trades: TradeDto[] | null;
-  candleCharts: CandleChartDto[] | null;
+  tickers: Record<string, TickerDto | null>;
+  orderbooks: Record<string, OrderbookDto | null>;
+  trades: Record<string, TradeDto[] | null>;
+  candleCharts: Record<string, CandleChartDto[] | null>;
 }
 
 const WebSocketContext = createContext<WebSocketContextProps>({
-  ticker: null,
-  orderbook: null,
-  trades: null,
-  candleCharts: null,
+  tickers: {},
+  orderbooks: {},
+  trades: {},
+  candleCharts: {},
 });
 
 export const WebSocketProvider = ({
@@ -39,53 +44,65 @@ export const WebSocketProvider = ({
   subscriptions = [],
 }: {
   children: ReactNode;
-  subscriptions: SubscriptionKey[]; // 2. 구독 키를 제한된 타입으로 설정
+  subscriptions: Subscription[];
 }) => {
-  const { market } = useParams();
+  const { market } = useParams() as { market: string }; // URL에서 market 가져오기
   const pathname = usePathname();
   const { connect, isConnected, subscribe, unsubscribe } = useWebSocketStore();
 
-  const [ticker, setTicker] = useState<TickerDto | null>(null);
-  const [orderbook, setOrderbook] = useState<OrderbookDto | null>(null);
-  const [trades, setTrades] = useState<TradeDto[] | null>(null);
-  const [candles, setCandles] = useState<CandleChartDto[] | null>(null);
+  const [tickers, setTicker] = useState<Record<string, TickerDto | null>>({});
+  const [orderbooks, setOrderbook] = useState<
+    Record<string, OrderbookDto | null>
+  >({});
+  const [trades, setTrades] = useState<Record<string, TradeDto[] | null>>({});
+  const [candles, setCandles] = useState<
+    Record<string, CandleChartDto[] | null>
+  >({});
 
   // WebSocket 연결
   useEffect(() => {
     connect();
   }, []);
 
-  // 페이지에서 받은 subscriptions에 맞춰 동적으로 구독 수행
   useEffect(() => {
-    if (!market || !isConnected || subscriptions.length === 0) return;
+    if (!isConnected || subscriptions.length === 0) return;
 
-    // 3. availableSubscriptions의 타입을 명시적으로 정의
     const availableSubscriptions: Record<
-      SubscriptionKey,
-      { dest: string; callback: (msg: IMessage) => void }
+      SubscriptionType,
+      (market: string) => { dest: string; callback: (msg: IMessage) => void }
     > = {
-      ticker: {
+      ticker: (market) => ({
         dest: `/sub/coin/ticker/${market}`,
-        callback: (msg: IMessage) => setTicker(JSON.parse(msg.body)),
-      },
-      orderbook: {
+        callback: (msg: IMessage) =>
+          setTicker((prev) => ({ ...prev, [market]: JSON.parse(msg.body) })),
+      }),
+      orderbook: (market) => ({
         dest: `/sub/coin/orderbook/${market}`,
-        callback: (msg: IMessage) => setOrderbook(JSON.parse(msg.body)),
-      },
-      trade: {
+        callback: (msg: IMessage) =>
+          setOrderbook((prev) => ({ ...prev, [market]: JSON.parse(msg.body) })),
+      }),
+      trade: (market) => ({
         dest: `/sub/coin/trade/${market}`,
-        callback: (msg: IMessage) => setTrades(JSON.parse(msg.body)),
-      },
-      candle: {
+        callback: (msg: IMessage) =>
+          setTrades((prev) => ({ ...prev, [market]: JSON.parse(msg.body) })),
+      }),
+      candle: (market) => ({
         dest: `/sub/coin/candle/${market}`,
-        callback: (msg: IMessage) => setCandles(JSON.parse(msg.body)),
-      },
+        callback: (msg: IMessage) =>
+          setCandles((prev) => ({ ...prev, [market]: JSON.parse(msg.body) })),
+      }),
     };
 
-    // 4. 올바른 키로 접근할 수 있도록 TypeScript가 인식할 수 있게 처리
-    const activeSubscriptions = subscriptions
-      .map((key) => availableSubscriptions[key as SubscriptionKey]) // 타입 캐스팅 추가
-      .filter(Boolean); // 존재하는 값만 필터링
+    // `markets`가 없거나 빈 배열이면 `useParams()`에서 market을 가져와 사용
+    const updatedSubscriptions = subscriptions.map(({ type, markets }) => ({
+      type,
+      markets: markets && markets.length > 0 ? markets : [market],
+    }));
+
+    const activeSubscriptions = updatedSubscriptions.flatMap(
+      ({ type, markets }) =>
+        markets!.map((market) => availableSubscriptions[type](market))
+    );
 
     activeSubscriptions.forEach(({ dest, callback }) => {
       subscribe(dest, callback);
@@ -100,7 +117,7 @@ export const WebSocketProvider = ({
 
   return (
     <WebSocketContext.Provider
-      value={{ ticker, orderbook, trades, candleCharts: candles }}
+      value={{ tickers, orderbooks, trades, candleCharts: candles }}
     >
       {children}
     </WebSocketContext.Provider>

--- a/frontend/src/app/context/WebSocketContext.tsx
+++ b/frontend/src/app/context/WebSocketContext.tsx
@@ -43,8 +43,7 @@ export const WebSocketProvider = ({
 }) => {
   const { market } = useParams();
   const pathname = usePathname();
-  const { connect, disconnect, isConnected, subscribe, unsubscribe } =
-    useWebSocketStore();
+  const { connect, isConnected, subscribe, unsubscribe } = useWebSocketStore();
 
   const [ticker, setTicker] = useState<TickerDto | null>(null);
   const [orderbook, setOrderbook] = useState<OrderbookDto | null>(null);
@@ -54,7 +53,6 @@ export const WebSocketProvider = ({
   // WebSocket 연결
   useEffect(() => {
     connect();
-    return () => disconnect();
   }, []);
 
   // 페이지에서 받은 subscriptions에 맞춰 동적으로 구독 수행

--- a/frontend/src/app/store/webSocketStore.ts
+++ b/frontend/src/app/store/webSocketStore.ts
@@ -5,7 +5,6 @@ interface WebSocketState {
   client: Client | null;
   isConnected: boolean;
   connect: () => void;
-  disconnect: () => void;
   subscribe: (
     destination: string,
     callback: (message: IMessage) => void
@@ -41,15 +40,6 @@ export const useWebSocketStore = create<WebSocketState>((set, get) => ({
 
     client.activate();
     set({ client });
-  },
-
-  // 웹소켓 연결 해제 함수
-  disconnect: () => {
-    const client = get().client;
-    if (client) {
-      client.deactivate();
-      set({ client: null, isConnected: false });
-    }
   },
 
   // 구독 함수


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #65 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- useEffect 훅에서 disconnect를 하면 페이지 이동 시 웹소켓을 재 연결해야 합니다. 이를 막기 위해 disconnect함수를 삭제했습니다.
- WebsocketProvider에 markets 파라미터를 추가했습니다.(market이 url에 없는 경우에도 웹소켓 연결이 필요하기 때문)
```javascript
// market을 url에서 가져올 수 있는 경우
export default function Page() {
  return (
    <WebSocketProvider
      subscriptions={[ // 필요한 구독만 추가
        { type: "ticker", markets: [] },
        { type: "orderbook", markets: [] },
        { type: "trade", markets: [] },
        { type: "candle", markets: [] },
      ]}
    >
      <ClientPage />
    </WebSocketProvider>
  );
}
```

```javascript
// markets을 서버에서 가져오는 경우
export default function Page() {
  return (
    <WebSocketProvider
      subscriptions={[ // 필요한 구독만 추가, markets 데이터는 서버 api를 통해 가져옵니다.
        { type: "ticker", markets },
        { type: "orderbook", markets },
        { type: "trade", markets },
        { type: "candle", markets },
      ]}
    >
      <ClientPage />
    </WebSocketProvider>
  );
}

```

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #65