### PR TITLE
bug: process and display mock trades in ClientPage

### DIFF
--- a/frontend/src/app/coin/[market]/ClientPage.tsx
+++ b/frontend/src/app/coin/[market]/ClientPage.tsx
@@ -12,7 +12,7 @@ import {
   generateMockNews,
 } from "@/app/utils/mockData";
 import { useWebSocket } from "@/app/context/WebSocketContext";
-import type { CandleItem, CandleChartDto } from "@/app/types";
+import type {CandleItem, CandleChartDto, TradeDto} from "@/app/types";
 import axios from "axios";
 
 export default function ClientPage() {
@@ -76,8 +76,18 @@ export default function ClientPage() {
   }, [market, candleType, minuteUnit]);
 
   // Mock data
-  const orderbook = generateMockOrderbook();
-  const news = generateMockNews();
+  const rawTrades = generateMockTrades();
+  const processedTrades = Object.keys(rawTrades).reduce((acc, key) => {
+    const trade = rawTrades[key];
+    acc[key] = {
+      ...trade,
+      tradePrice: typeof trade.tradePrice === "number" ? trade.tradePrice : 0,
+      tradeVolume: typeof trade.tradeVolume === "number" ? trade.tradeVolume : 0,
+      timestamp: trade.timestamp ?? Date.now(),
+      sequentialId: trade.sequentialId ?? key,
+    };
+    return acc;
+  }, {} as Record<string, TradeDto>);
 
   return (
       <div>
@@ -138,7 +148,7 @@ export default function ClientPage() {
               setMinuteUnit={setMinuteUnit}
           />
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <TradeList trades={generateMockTrades()} />
+            <TradeList trades={processedTrades} />
             <OrderbookList orderbook={generateMockOrderbook()} currentPrice={ticker?.tradePrice || 0} />
           </div>
           <div className="w-full">


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> 

## 작업 내용
undefined 오류가 발생해서 임시로 대충 프론트 돌아가게끔만 고쳐놨습니다 (목 데이터 관련 오류)

설명
generateMockTrades()로 받은 원본 데이터를 rawTrades에 저장한 후, reduce를 사용해 각 trade 객체에 대해
tradePrice와 tradeVolume이 정의되어 있지 않으면 0으로 대체
timestamp와 sequentialId도 기본값(없을 경우 현재 시간이나 index 값)으로 채워줍니다.
processedTrades를 TradeList 컴포넌트에 전달하면, 내부에서 toFixed나 toLocaleString 호출 시 undefined가 아닌 값으로 동작하게 됩니다.
> 

## 스크린샷 (선택)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #80