### PR TITLE
Feat/127 market for ticker

### DIFF
--- a/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/controller/MarketController.java
@@ -31,19 +31,12 @@ public class MarketController {
 
 	private final MarketService marketService;
 
-	/*@Operation(summary = "마켓 전체 조회")
-	@GetMapping
-	public ResponseEntity<Page<MarketResponse>> getMarkets(@PageableDefault(sort = "code") Pageable pageable) {
-		return ResponseEntity.ok(marketService.getMarkets(pageable)
-			.map(MarketResponse::from));
-	}*/
-
-	@Operation(summary = "특정 마켓 정보 조회")
+	@Operation(summary = "북마크한 특정 마켓 정보 조회")
 	@GetMapping("/{code}")
-	public ResponseEntity<MarketResponse> getMarketByCode(
+	public ResponseEntity<MarketResponse> getMarketByUserAndCode(
 		@AuthenticationPrincipal CustomUserPrincipal principal,
 		@PathVariable("code") String code) {
-		MarketResponse response = MarketResponse.from(marketService.getMarketByCode(principal, code));
+		MarketResponse response = MarketResponse.from(marketService.getMarketByUserAndCode(principal, code));
 		return ResponseEntity.ok(response);
 	}
 

--- a/backend/src/main/java/com/coing/domain/coin/market/entity/Market.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/entity/Market.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 public class Market extends BaseEntity {
 
 	@Id

--- a/backend/src/main/java/com/coing/domain/coin/market/service/MarketCacheService.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/service/MarketCacheService.java
@@ -1,6 +1,9 @@
 package com.coing.domain.coin.market.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
@@ -20,13 +23,16 @@ public class MarketCacheService {
 	private final MarketRepository marketRepository;
 
 	@CachePut(value = "markets")
-	public List<Market> updateMarketCache(List<Market> markets) {
+	public Map<String, Market> updateMarketCache(List<Market> markets) {
 		log.info("[MarketCacheService] Updating cache with {} markets", markets.size());
-		return markets;
+
+		return markets.stream()
+			.collect(Collectors.toMap(Market::getCode, Function.identity()));
 	}
 
 	@Cacheable(value = "markets")
-	public List<Market> getCachedMarketList() {
-		return marketRepository.findAll();
+	public Map<String, Market> getCachedMarketMap() {
+		return marketRepository.findAll().stream()
+			.collect(Collectors.toMap(Market::getCode, Function.identity()));
 	}
 }

--- a/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
@@ -1,8 +1,10 @@
 package com.coing.domain.coin.market.service;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -24,6 +26,7 @@ import com.coing.domain.coin.market.entity.Market;
 import com.coing.domain.coin.market.repository.MarketRepository;
 import com.coing.domain.user.CustomUserPrincipal;
 import com.coing.global.exception.BusinessException;
+import com.coing.util.MessageUtil;
 import com.coing.util.PageUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -34,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MarketService {
 
+	private final MessageUtil messageUtil;
 	@Value("${upbit.market.uri}")
 	private String UPBIT_MARKET_URI;
 
@@ -71,14 +75,14 @@ public class MarketService {
 
 	// 컨트롤러
 	public Page<Market> getMarkets(Pageable pageable) {
-		List<Market> allMarkets = marketCacheService.getCachedMarketList();
+		List<Market> allMarkets = getCachedMarketList();
 		return PageUtil.paginate(allMarkets, pageable);
 	}
 
 	// 컨트롤러
 	public Page<MarketResponseDto> getAllMarketsByQuote(CustomUserPrincipal principal, String type, Pageable pageable) {
 		log.info("[Market] Get all market list by quote currency");
-		List<Market> filtered = marketCacheService.getCachedMarketList().stream()
+		List<Market> filtered = getCachedMarketList().stream()
 			.filter(market -> market.getCode().startsWith(type))
 			.toList();
 
@@ -109,8 +113,8 @@ public class MarketService {
 	}
 
 	// 컨트롤러
-	public MarketResponseDto getMarketByCode(CustomUserPrincipal principal, String code) {
-		List<Market> cachedMarkets = marketCacheService.getCachedMarketList();
+	public MarketResponseDto getMarketByUserAndCode(CustomUserPrincipal principal, String code) {
+		List<Market> cachedMarkets = getCachedMarketList();
 		boolean isBookmarked = principal != null && bookmarkRepository.existsByUserIdAndMarketCode(principal.id(), code);
 
 		return cachedMarkets.stream()
@@ -118,5 +122,14 @@ public class MarketService {
 			.findFirst()
 			.map(m -> MarketResponseDto.of(m, isBookmarked))
 			.orElseThrow(() -> new BusinessException("Market not found", HttpStatus.NOT_FOUND));
+	}
+
+
+	public List<Market> getCachedMarketList() {
+		return marketCacheService.getCachedMarketMap()
+			.values()
+			.stream()
+			.sorted(Comparator.comparing(Market::getCode))
+			.toList();
 	}
 }

--- a/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/service/MarketService.java
@@ -124,6 +124,11 @@ public class MarketService {
 			.orElseThrow(() -> new BusinessException("Market not found", HttpStatus.NOT_FOUND));
 	}
 
+	public Market getCachedMarketByCode(String code) {
+		return Optional.ofNullable(marketCacheService.getCachedMarketMap().get(code))
+			.orElseThrow(() -> new BusinessException(messageUtil.resolveMessage("market.not.found"),
+				HttpStatus.NOT_FOUND));
+	}
 
 	public List<Market> getCachedMarketList() {
 		return marketCacheService.getCachedMarketMap()

--- a/backend/src/main/java/com/coing/domain/coin/ticker/service/TickerService.java
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/service/TickerService.java
@@ -47,7 +47,7 @@ public class TickerService {
 	}
 
 	public void updateTicker(Ticker ticker) {
-		Market market = marketService.getMarketByCode(ticker.getCode());
+		Market market = marketService.getCachedMarketByCode(ticker.getCode());
 		TickerDto dto = TickerDto.from(ticker, market);
 		tickerCache.put(ticker.getCode(), dto);
 		publish(dto);

--- a/backend/src/main/java/com/coing/infra/upbit/util/UpbitRequestBuilder.java
+++ b/backend/src/main/java/com/coing/infra/upbit/util/UpbitRequestBuilder.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.coing.domain.coin.market.entity.Market;
 import com.coing.domain.coin.market.service.MarketCacheService;
 import com.coing.infra.upbit.dto.UpbitWebSocketFormatDto;
 import com.coing.infra.upbit.dto.UpbitWebSocketTicketDto;
@@ -24,7 +23,7 @@ public class UpbitRequestBuilder {
 	private final MarketCacheService marketCacheService;
 
 	public String makeRequest(EnumUpbitRequestType type) throws JsonProcessingException {
-		List<String> codes = marketCacheService.getCachedMarketList().stream().map(Market::getCode).toList();
+		List<String> codes = marketCacheService.getCachedMarketMap().keySet().stream().toList();
 		UpbitWebSocketTicketDto ticketDto = UpbitWebSocketTicketDto.builder()
 			.ticket(type.getValue())
 			.build();

--- a/backend/src/test/java/com/coing/domain/coin/market/service/MarketServiceTest.java
+++ b/backend/src/test/java/com/coing/domain/coin/market/service/MarketServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -107,11 +108,12 @@ public class MarketServiceTest {
 	@DisplayName("t4: 코인 목록 전체 조회 - 정상 동작 테스트")
 	void testGetMarkets() {
 		// Given
-		List<Market> mockMarkets = Arrays.asList(
-			new Market("KRW-BTC", "비트코인", "Bitcoin"),
-			new Market("KRW-ETH", "이더리움", "Ethereum")
+		Map<String, Market> mockMarketMap = Map.of(
+			"KRW-BTC", new Market("KRW-BTC", "비트코인", "Bitcoin"),
+			"KRW-ETH", new Market("KRW-ETH", "이더리움", "Ethereum")
 		);
-		when(marketCacheService.getCachedMarketList()).thenReturn(mockMarkets);
+
+		when(marketCacheService.getCachedMarketMap()).thenReturn(mockMarketMap);
 		Pageable pageable = PageRequest.of(0, 10);
 
 		// When
@@ -127,11 +129,12 @@ public class MarketServiceTest {
 	void getAllCoinsByMarket_ShouldReturnFilteredMarkets() {
 		// given
 		String type = "KRW";
-		List<Market> mockMarkets = Arrays.asList(
-			new Market("KRW-BTC", "비트코인", "Bitcoin"),
-			new Market("KRW-ETH", "이더리움", "Ethereum")
+		Map<String, Market> mockMarketMap = Map.of(
+			"KRW-BTC", new Market("KRW-BTC", "비트코인", "Bitcoin"),
+			"KRW-ETH", new Market("KRW-ETH", "이더리움", "Ethereum")
 		);
-		when(marketCacheService.getCachedMarketList()).thenReturn(mockMarkets);
+
+		when(marketCacheService.getCachedMarketMap()).thenReturn(mockMarketMap);
 		Pageable pageable = PageRequest.of(0, 10);
 
 		// when
@@ -149,7 +152,7 @@ public class MarketServiceTest {
 		// given
 		String type = "USD";
 		Pageable pageable = PageRequest.of(0, 10);
-		when(marketCacheService.getCachedMarketList()).thenReturn(Collections.emptyList());
+		when(marketCacheService.getCachedMarketMap()).thenReturn(Collections.emptyMap());
 
 		// when
 		Page<MarketResponseDto> result = marketService.getAllMarketsByQuote(null, type, pageable);

--- a/backend/src/test/java/com/coing/domain/coin/ticker/service/TickerServiceTest.java
+++ b/backend/src/test/java/com/coing/domain/coin/ticker/service/TickerServiceTest.java
@@ -108,7 +108,7 @@ public class TickerServiceTest {
 	@DisplayName("getTicker 성공 - 존재하는 마켓 코드 조회")
 	void getTicker_Success() throws Exception {
 		// given
-		when(marketService.getMarketByCode(anyString())).thenReturn(testMarket);
+		when(marketService.getCachedMarketByCode(anyString())).thenReturn(testMarket);
 		tickerService.updateTicker(testTicker);
 
 		// when
@@ -136,7 +136,7 @@ public class TickerServiceTest {
 	@DisplayName("updateTicker 성공 - 캐시에 저장 확인")
 	void updateTicker() throws Exception {
 		// when
-		when(marketService.getMarketByCode(anyString())).thenReturn(testMarket);
+		when(marketService.getCachedMarketByCode(anyString())).thenReturn(testMarket);
 		tickerService.updateTicker(testTicker);
 
 		// then
@@ -195,7 +195,7 @@ public class TickerServiceTest {
 	@DisplayName("publishCachedTickers 성공 - WebSocket을 통해 데이터 전송")
 	void publishCachedTickers() throws JsonProcessingException {
 		// given
-		when(marketService.getMarketByCode(anyString())).thenReturn(testMarket);
+		when(marketService.getCachedMarketByCode(anyString())).thenReturn(testMarket);
 		tickerService.updateTicker(testTicker);
 		TickerDto dto = TickerDto.from(testTicker, testMarket);
 


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #127 

## 작업 내용

> 기존에 있었던 market 조회 메서드가 병합하는 과정에서 누락되어 다시 추가합니다.
market 조회 시 캐시 데이터를 활용합니다.
market 데이터 캐싱 타입을 List -> Map으로 변경했습니다.

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #127