### PR TITLE
feat: news crawling

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -58,6 +58,10 @@ jobs:
           JWT_EXPIRE_SECONDS: ${{ secrets.JWT_EXPIRE_SECONDS }}
           JWT_REFRESH_EXPIRE_SECONDS: ${{ secrets.JWT_REFRESH_EXPIRE_SECONDS }}
           UPBIT_WS_URI: ${{ secrets.UPBIT_WS_URI }}
+          MAIL_HOST: ${{ secrets.MAIL_HOST }}
+          MAIL_PORT: ${{ secrets.MAIL_PORT }}
+          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/backend/src/main/java/com/coing/domain/coin/market/repository/MarketRepository.java
+++ b/backend/src/main/java/com/coing/domain/coin/market/repository/MarketRepository.java
@@ -1,5 +1,7 @@
 package com.coing.domain.coin.market.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +12,6 @@ import com.coing.domain.coin.market.entity.Market;
 @Repository
 public interface MarketRepository extends JpaRepository<Market, String> {
 	Page<Market> findByCodeStartingWith(String prefix, Pageable pageable);
+
+	Optional<Market> findByCode(String code);
 }

--- a/backend/src/main/java/com/coing/domain/news/controller/NewsController.java
+++ b/backend/src/main/java/com/coing/domain/news/controller/NewsController.java
@@ -1,0 +1,38 @@
+package com.coing.domain.news.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coing.domain.news.service.NewsService;
+
+import io.swagger.v3.oas.annotations.Operation;
+
+@RestController
+@RequestMapping("/api")
+public class NewsController {
+
+	private final NewsService newsService;
+
+	public NewsController(NewsService newsService) {
+		this.newsService = newsService;
+	}
+
+	/**
+	 * 마켓 코드로 뉴스 조회 (검색어는 해당 마켓의 한국 이름 사용)
+	 */
+	@Operation(summary = "마켓 코드로 뉴스 조회 (검색어는 해당 마켓의 한국 이름 사용)")
+	@GetMapping("/news")
+	public ResponseEntity<String> searchNews(
+		@RequestParam(name = "market") String marketCode,
+		@RequestParam(name = "display", defaultValue = "100") int display,
+		@RequestParam(name = "start", defaultValue = "1") int start,
+		@RequestParam(name = "sort", defaultValue = "sim") String sort,
+		@RequestParam(name = "format", defaultValue = "json") String format) {
+
+		String result = newsService.searchNewsByMarketCode(marketCode, display, start, sort, format);
+		return ResponseEntity.ok(result);
+	}
+}

--- a/backend/src/main/java/com/coing/domain/news/service/NewsService.java
+++ b/backend/src/main/java/com/coing/domain/news/service/NewsService.java
@@ -1,0 +1,124 @@
+package com.coing.domain.news.service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.coing.domain.coin.market.entity.Market;
+import com.coing.domain.coin.market.repository.MarketRepository;
+
+@Service
+public class NewsService {
+
+	@Value("${naver.client.id}")
+	private String clientId;
+
+	@Value("${naver.client.secret}")
+	private String clientSecret;
+
+	private final MarketRepository marketRepository;
+
+	public NewsService(MarketRepository marketRepository) {
+		this.marketRepository = marketRepository;
+	}
+
+	/**
+	 * 마켓 코드를 받아서 해당 마켓의 한국어 이름을 쿼리로 사용해 뉴스 검색 API 호출
+	 */
+	public String searchNewsByMarketCode(String marketCode, int display, int start, String sort, String format) {
+		// MarketRepository를 사용해 마켓 정보 조회
+		Market market = marketRepository.findByCode(marketCode)
+			.orElseThrow(() -> new NoSuchElementException("Market not found for code: " + marketCode));
+		String query = market.getKoreanName(); // 한국어 이름을 검색어로 사용
+		return searchNews(query, display, start, sort, format);
+	}
+
+	/**
+	 * 네이버 뉴스 검색 API 호출 (JSON)
+	 *
+	 * @param query   검색어 ()
+	 * @param display 한 번에 표시할 결과 개수
+	 * @param start   검색 시작 위치
+	 * @param sort    정렬 방식 ("sim" 또는 "date")
+	 * @param format  결과 포맷 ("json" 또는 "xml")
+	 * @return API 응답 문자열
+	 */
+	public String searchNews(String query, int display, int start, String sort, String format) {
+		String encodedQuery;
+		try {
+			encodedQuery = URLEncoder.encode(query, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException("검색어 인코딩 실패", e);
+		}
+
+		String apiURL = "https://openapi.naver.com/v1/search/news." + format +
+			"?query=" + encodedQuery +
+			"&display=" + display +
+			"&start=" + start +
+			"&sort=" + sort;
+
+		Map<String, String> requestHeaders = new HashMap<>();
+		requestHeaders.put("X-Naver-Client-Id", clientId);
+		requestHeaders.put("X-Naver-Client-Secret", clientSecret);
+
+		return get(apiURL, requestHeaders);
+	}
+
+	private String get(String apiUrl, Map<String, String> requestHeaders) {
+		HttpURLConnection con = connect(apiUrl);
+		try {
+			con.setRequestMethod("GET");
+			for (Map.Entry<String, String> header : requestHeaders.entrySet()) {
+				con.setRequestProperty(header.getKey(), header.getValue());
+			}
+
+			int responseCode = con.getResponseCode();
+			if (responseCode == HttpURLConnection.HTTP_OK) { // 정상 호출
+				return readBody(con.getInputStream());
+			} else { // 오류 발생
+				return readBody(con.getErrorStream());
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("API 요청과 응답 실패", e);
+		} finally {
+			con.disconnect();
+		}
+	}
+
+	private HttpURLConnection connect(String apiUrl) {
+		try {
+			URL url = new URL(apiUrl);
+			return (HttpURLConnection)url.openConnection();
+		} catch (MalformedURLException e) {
+			throw new RuntimeException("API URL이 잘못되었습니다: " + apiUrl, e);
+		} catch (IOException e) {
+			throw new RuntimeException("연결 실패: " + apiUrl, e);
+		}
+	}
+
+	private String readBody(InputStream body) {
+		InputStreamReader streamReader = new InputStreamReader(body);
+		try (BufferedReader lineReader = new BufferedReader(streamReader)) {
+			StringBuilder responseBody = new StringBuilder();
+			String line;
+			while ((line = lineReader.readLine()) != null) {
+				responseBody.append(line);
+			}
+			return responseBody.toString();
+		} catch (IOException e) {
+			throw new RuntimeException("API 응답을 읽는 데 실패했습니다.", e);
+		}
+	}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -74,5 +74,5 @@ upbit:
 
 naver:
   client:
-    id: ${NAVER_CLIENT_ID}
-    secret: ${NAVER_CLIENT_SECRET}
+    id: ${NAVER_CLIENT_ID:default_client_id}
+    secret: ${NAVER_CLIENT_SECRET:default_client_secret}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -74,5 +74,5 @@ upbit:
 
 naver:
   client:
-    id: eeIXlekB447ZTOL1nEq6
-    secret: cinZywG_Gb
+    id: ${NAVER_CLIENT_ID}
+    secret: ${NAVER_CLIENT_SECRET}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: coing
   profiles:
-    active: ${SPRING_ACTIVE_PROFILES:prod}
+    active: ${SPRING_ACTIVE_PROFILES:dev}
   config:
     import: optional:file:./.env[.properties]
   output:
@@ -64,7 +64,6 @@ custom:
     mail-verification-url: ${EMAIL_VERIFICATION_URL:http://localhost:3000/api/auth/verify-email-?token=}
     password-reset-url: ${PASSWORD_RESET_URL:http://localhost:3000/user/password-reset?token=}
 
-
 upbit:
   websocket:
     uri: ${UPBIT_WS_URI:wss://api.upbit.com/websocket/v1}
@@ -72,3 +71,8 @@ upbit:
     uri: ${UPBIT_MARKET_URI:https://api.upbit.com/v1/market/all}
   trade:
     uri: ${UPBIT_TRADE_URI:https://api.upbit.com/v1/trades/ticks}
+
+naver:
+  client:
+    id: eeIXlekB447ZTOL1nEq6
+    secret: cinZywG_Gb

--- a/frontend/src/app/api/news/route.ts
+++ b/frontend/src/app/api/news/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+
+export type NewsItem = {
+  id: string;
+  title: string;
+  summary: string;
+  source: string;
+  publishedAt: string;
+  url: string;
+};
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const market = searchParams.get('market');
+  if (!market) {
+    return NextResponse.json(
+      { error: 'market parameter is required' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const backendUrl = 'http://localhost:8080';
+    const url = `${backendUrl}/api/news?market=${encodeURIComponent(
+      market
+    )}&display=100&start=1&sort=sim&format=json`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch news' },
+        { status: response.status }
+      );
+    }
+    const data = await response.json();
+    if (data && Array.isArray(data.items)) {
+      const transformedNews: NewsItem[] = data.items.map((item: any) => ({
+        id: item.id || item.link, // id가 없으면 link를 id로 사용
+        title: item.title,
+        summary: item.summary || item.description || '',
+        source:
+          item.source ||
+          (item.originallink ? new URL(item.originallink).hostname : ''),
+        publishedAt: item.publishedAt || item.pubDate || '',
+        url: item.url || item.link,
+      }));
+      return NextResponse.json(transformedNews, { status: 200 });
+    } else {
+      return NextResponse.json(
+        { error: 'Unexpected data format' },
+        { status: 500 }
+      );
+    }
+  } catch (err) {
+    console.error('뉴스 데이터 호출 오류:', err);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/coin/[market]/ClientPage.tsx
+++ b/frontend/src/app/coin/[market]/ClientPage.tsx
@@ -6,57 +6,57 @@ import { useWebSocket } from '@/context/WebSocketContext';
 import OrderbookList from '../components/orderbook/OrderbookList';
 import CandleChart from '../components/CandleChart';
 import NewsList from '../components/NewsList';
-import { generateMockNews } from '@/lib/utils';
-import type { CandleItem } from '@/types';
+import type { CandleItem, NewsItem } from '@/types';
 import TradeList from '@/app/coin/components/TradeList';
 import Ticker from '@/app/coin/components/Ticker';
 import { fetchApi } from '@/lib/api';
 
 export default function ClientPage() {
   const { market } = useParams() as { market: string };
-  const { tickers } = useWebSocket();
+  const { tickers, trades, orderbooks } = useWebSocket();
   const ticker = tickers?.[market] ?? null;
-  const { trades } = useWebSocket();
   const trade = trades?.[market] ?? null;
-  const { orderbooks } = useWebSocket();
   const orderbook = orderbooks?.[market] ?? null;
 
   // 보정된 캔들 데이터를 저장
   const [candles, setCandles] = useState<CandleItem[]>([]);
   // 선택한 봉 단위: seconds, minutes, days, weeks, months, years
   const [candleType, setCandleType] = useState<
-    'seconds' | 'minutes' | 'days' | 'weeks' | 'months' | 'years'
+      'seconds' | 'minutes' | 'days' | 'weeks' | 'months' | 'years'
   >('seconds');
   // 분봉일 경우 단위 선택 (예: 1, 3, 5, 10, 15, 30, 60, 240)
   const [minuteUnit, setMinuteUnit] = useState(1);
 
-  // 봉 단위에 따른 폴링 간격(ms)을 결정하는 함수
+  // 뉴스 데이터 state (NewsItem 배열)
+  const [news, setNews] = useState<NewsItem[]>([]);
+
+  // 봉 단위에 따른 폴링 간격(ms) 결정 함수
   const getPollingInterval = (type: string): number => {
     switch (type) {
       case 'seconds':
-        return 1000; // 초봉은 1초
+        return 1000;
       case 'minutes':
-        return 30000; // 분봉은 30초
+        return 30000;
       case 'days':
-        return 3600000; // 일봉은 1시간
+        return 3600000;
       case 'weeks':
       case 'months':
       case 'years':
-        return 86400000; // 주, 월, 연봉은 하루 주기 업데이트
+        return 86400000;
       default:
         return 1000;
     }
   };
 
+  // 캔들 데이터 fetch
   useEffect(() => {
     const fetchCandles = async () => {
       try {
-        const unitQuery = candleType === 'minutes' && minuteUnit ? `&unit=${minuteUnit}` : '';
+        const unitQuery =
+            candleType === 'minutes' && minuteUnit ? `&unit=${minuteUnit}` : '';
         const data = await fetchApi<CandleItem[]>(
-          `/api/candle?market=${market}&candleType=${candleType}${unitQuery}`,
-          {
-            method: 'GET',
-          },
+            `/api/candle?market=${market}&candleType=${candleType}${unitQuery}`,
+            { method: 'GET' }
         );
         setCandles(data);
       } catch (err) {
@@ -71,27 +71,42 @@ export default function ClientPage() {
     return () => clearInterval(interval);
   }, [market, candleType, minuteUnit]);
 
-  return (
-    <div>
-      <Ticker market={market} ticker={ticker} />
+  // 뉴스 데이터 fetch (API 라우트 통해 변환된 데이터 사용)
+  useEffect(() => {
+    const fetchNews = async () => {
+      try {
+        const url = `/api/news?market=${encodeURIComponent(market)}`;
+        const data = await fetchApi<NewsItem[]>(url, { method: 'GET' });
+        setNews(data);
+      } catch (err) {
+        console.error('뉴스 데이터 호출 오류:', err);
+      }
+    };
 
-      <div className="space-y-4">
-        {/* CandleChart 컴포넌트에 setCandleType, minuteUnit, setMinuteUnit 전달 */}
-        <CandleChart
-          candles={candles}
-          candleType={candleType}
-          setCandleType={setCandleType}
-          minuteUnit={minuteUnit}
-          setMinuteUnit={setMinuteUnit}
-        />
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <TradeList market={market} trade={trade} />
-          <OrderbookList market={market} orderbook={orderbook} />
-        </div>
-        <div className="w-full">
-          <NewsList news={generateMockNews()} />
+    if (market) {
+      fetchNews();
+    }
+  }, [market]);
+
+  return (
+      <div>
+        <Ticker market={market} ticker={ticker} />
+        <div className="space-y-4">
+          <CandleChart
+              candles={candles}
+              candleType={candleType}
+              setCandleType={setCandleType}
+              minuteUnit={minuteUnit}
+              setMinuteUnit={setMinuteUnit}
+          />
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <TradeList market={market} trade={trade} />
+            <OrderbookList market={market} orderbook={orderbook} />
+          </div>
+          <div className="w-full">
+            <NewsList news={news} />
+          </div>
         </div>
       </div>
-    </div>
   );
 }

--- a/frontend/src/app/coin/components/NewsList.tsx
+++ b/frontend/src/app/coin/components/NewsList.tsx
@@ -1,12 +1,35 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import type { NewsItem } from '@/types';
 
 interface NewsListProps {
   news: NewsItem[];
 }
 
-export default function NewsList({ news }: NewsListProps) {
+export default function NewsList({ news: initialNews }: NewsListProps) {
+  const [news, setNews] = useState<NewsItem[]>(initialNews);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 5;
+
+  // initialNews가 변경될 때 state를 업데이트
+  useEffect(() => {
+    setNews(initialNews);
+    setCurrentPage(1);
+  }, [initialNews]);
+
+  // 새로고침 버튼 클릭 시 초기 데이터를 재설정하는 예시
+  const refreshNews = async () => {
+    setNews(initialNews);
+    setCurrentPage(1);
+  };
+
+  // 페이지네이션 계산
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentNews = news.slice(indexOfFirstItem, indexOfLastItem);
+  const totalPages = Math.ceil(news.length / itemsPerPage);
+
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleDateString('ko-KR', {
@@ -19,27 +42,66 @@ export default function NewsList({ news }: NewsListProps) {
   };
 
   return (
-    <div className="bg-card rounded-lg shadow-sm overflow-hidden">
-      <div className="p-4 border-b border-muted">
-        <h2 className="text-lg font-semibold">뉴스</h2>
-      </div>
+      <div className="bg-card rounded-lg shadow-sm overflow-hidden">
+        <div className="p-4 border-b border-muted flex justify-between items-center">
+          <h2 className="text-lg font-semibold">뉴스</h2>
+          <button
+              onClick={refreshNews}
+              className="px-3 py-1 text-sm border rounded hover:bg-muted"
+          >
+            새로고침
+          </button>
+        </div>
 
-      <div className="overflow-y-auto max-h-[400px]">
-        <ul className="divide-y divide-muted">
-          {news.map((item) => (
-            <li key={item.id} className="p-4 hover:bg-muted">
-              <a href={item.url} className="block">
-                <h3 className="font-medium mb-1">{item.title}</h3>
-                <p className="text-sm text-secondary mb-2">{item.summary}</p>
-                <div className="flex justify-between text-xs text-primary">
-                  <span>{item.source}</span>
-                  <span>{formatDate(item.publishedAt)}</span>
-                </div>
-              </a>
-            </li>
-          ))}
-        </ul>
+        <div className="overflow-y-auto max-h-[400px]">
+          <ul className="divide-y divide-muted">
+            {currentNews.map((item, index) => (
+                <li key={item.id || index} className="p-4 hover:bg-muted">
+                  <a
+                      href={item.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block"
+                  >
+                    <h3
+                        className="font-medium mb-1"
+                        dangerouslySetInnerHTML={{ __html: item.title }}
+                    />
+                    <p
+                        className="text-sm text-secondary mb-2"
+                        dangerouslySetInnerHTML={{ __html: item.summary }}
+                    />
+                    <div className="flex justify-between text-xs text-primary">
+                      <span>{item.source}</span>
+                      <span>{formatDate(item.publishedAt)}</span>
+                    </div>
+                  </a>
+                </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex justify-center items-center p-4 space-x-4">
+          <button
+              onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+              disabled={currentPage === 1}
+              className="px-3 py-1 text-sm border rounded disabled:opacity-50"
+          >
+            이전
+          </button>
+          <span className="text-sm">
+            {currentPage} / {totalPages}
+          </span>
+          <button
+              onClick={() =>
+                  setCurrentPage((prev) => Math.min(prev + 1, totalPages))
+              }
+              disabled={currentPage === totalPages}
+              className="px-3 py-1 text-sm border rounded disabled:opacity-50"
+          >
+            다음
+          </button>
+        </div>
       </div>
-    </div>
   );
 }


### PR DESCRIPTION
## 연관된 이슈

> #141 
> 

## 작업 내용

> 네이버 검색 API를 탑재해서 뉴스 검색한 것 코인 상세페이지 뉴스 탭에 뿌려주게 만들었습니다.
> 프론트에서 마켓 코드 보내면 백엔드에서 마켓 코드로 한글 이름 검색해서 query에 한글 이름 보내서 그거로 뉴스 검색하게 했습니다.
> 실수로 네이버 시크릿 키 올려서 재발급 받고 환경 변수 처리했습니다. (도플러)

## 스크린샷 (선택)
![스크린샷 2025-03-14 170128](https://github.com/user-attachments/assets/1b8f3544-7118-442d-8c83-a78d30e81daa)

![스크린샷 2025-03-14 170109](https://github.com/user-attachments/assets/5c9096a4-8114-41db-b7a9-2070ac39b107)


## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #141